### PR TITLE
Adding examples of versioning to provide a place to link to for our expected processes.

### DIFF
--- a/RELEASE_PROCESS.MD
+++ b/RELEASE_PROCESS.MD
@@ -10,6 +10,24 @@ Smaller changes incur less risk, and releasing after each contribution ensures w
 
 Infrastructure stability for our users is critical so we aim to release predictably versioned cookbooks. Following Semver allows users to pin cookbook requirements in wrapper cookbooks or environment files, and avoid breaking changes. See <http://semver.org/>
 
+Cookbooks follow a `MAJOR.MINOR.PATCH` versioning scheme based on [Semantic Versioning](http://semver.org/).  
+
+Given a version number `MAJOR.MINOR.PATCH`:
+
+    `MAJOR` version releases (e.g. 1.x -> 2.x) will include breaking or backwards-incompatible changes.
+        Example: When updating a cookbook to use new chef-client features that are not available in older versions.
+        Example: When removing support for a platform, or version of a platform.
+    `MINOR` version releases (e.g. 1.1 -> 1.2) will include new features, bug fixes, and will be backwards-compatible to the best of the Maintainers' abilities.
+        Example: When adding a new custom resource to a cookbook.
+    `PATCH` version releases (e.g. 1.1.1 -> 1.1.2) will include backwards-compatible bug fixes.
+        Example: Fixing a misspelled attribute in a recipe.
+
+When incrementing a cookbook version, the following conditions will apply:
+
+    When `MAJOR` increases, `MINOR` and `PATCH` will be reset to zero (e.g. 11.X.X -> 12.0.0)
+        Note: New features that did not exist in version 1.1.0 may be released in 2.0.0 without any intermediary releases.
+    When `MINOR` increases, `PATCH` will be reset to zero (e.g. 11.3.x -> 11.4.0)
+
 ## Test Before Releasing
 
 Many cookbooks have integration tests that run using kitchen-dokken in Travis CI. For these cookbooks we're preforming integration testing on every commit. For others integration tests must be run locally and this should be done before any release to ensure high quality releases.


### PR DESCRIPTION
Rather than add this to the RFC here: https://github.com/chef/chef-rfc/pull/267 I've updated our doc as this is more of a living document and I don't think we want to get into the habit of doing RFCs for cookbook authoring. 